### PR TITLE
Add transcript alignment script and offline web player

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,91 @@
-"# NLM_podcast_transcript_runner" 
+# Notebook LM Podcast Transcript Runner
+
+This project helps you align Notebook LM generated podcast transcripts with the
+original Portuguese audio and play them back locally on your Android phone (or
+any modern browser) with synchronized bilingual subtitles.
+
+## Repository structure
+
+```
+├── scripts/
+│   └── build_vtt.py      # CLI tool to align transcripts and generate WebVTT
+├── webapp/
+│   ├── index.html        # Offline-friendly audio player UI
+│   ├── script.js         # Transcript rendering and synchronization logic
+│   └── styles.css        # Visual styling
+└── requirements.txt      # Python dependencies for alignment
+```
+
+## 1. Generate a WebVTT transcript
+
+Use the `build_vtt.py` script to align your Portuguese transcript (and optional
+English translation) with the MP3/MP4 audio exported from Notebook LM.
+
+1. Install Python dependencies (Python 3.9+ recommended):
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+   > The script relies on [faster-whisper](https://github.com/guillaumekln/faster-whisper),
+   > which downloads the requested Whisper model on first use. `small` is a good
+   > default, but you can switch to `medium` for better accuracy if your device
+   > has enough RAM.
+
+2. Prepare two plain-text files:
+   - `podcast.pt.txt`: Portuguese transcript, one speaker turn per line.
+   - `podcast.en.txt`: English translation, also one line per speaker turn (must
+     have the same number of non-empty lines as the Portuguese file).
+
+3. Run the alignment script:
+
+   ```bash
+   python scripts/build_vtt.py \
+     --audio path/to/podcast.mp3 \
+     --portuguese path/to/podcast.pt.txt \
+     --english path/to/podcast.en.txt \
+     --model small \
+     --output path/to/podcast.vtt
+   ```
+
+   - Omit `--english` if you only want the Portuguese transcript.
+   - Use `--dump-debug alignment.json` to inspect the computed cue boundaries.
+   - If the audio is MP4, pass the path as `--audio path/to/podcast.mp4` (the
+     script extracts audio automatically via ffmpeg shipped with `faster-whisper`).
+
+The result is a WebVTT file where each cue contains both the Portuguese line and
+its English translation using `<span class="pt">` and `<span class="en">` blocks.
+
+## 2. Load the files in the local player
+
+The `webapp/` folder contains a lightweight player that runs entirely offline in
+your mobile browser.
+
+1. Copy `webapp/` to your phone (or serve it locally with a static file server).
+2. Open `index.html` in Chrome/Firefox on Android. You can add it to your home
+   screen for quick access.
+3. Tap **Audio file** and select the podcast MP3/MP4 file.
+4. Tap **Transcript** and select the generated `.vtt` file.
+5. Playback controls will stay in sync with the transcript. Tap any cue to jump
+   to that segment. Toggle the translation visibility with the checkbox.
+
+Because everything happens client-side, your files remain on-device—nothing is
+uploaded to the internet.
+
+## Tips for better alignments
+
+- Make sure the Portuguese transcript closely matches the spoken audio (same
+  punctuation and speaker turns). When transcripts differ significantly, use the
+  `--dump-debug` output to spot cues that might need manual adjustment.
+- Consider using higher-quality Whisper models (`medium`, `large-v2`) for
+  trickier audio. They take longer to download but greatly improve accuracy.
+- You can fine-tune cue timings manually by editing the generated `.vtt` file
+  in any text editor—the player will pick up your adjustments automatically.
+
+## Roadmap ideas
+
+- Optional playback speed controls and looping for focused practice.
+- Support for exporting/ importing Anki cards per cue.
+- On-device storage of recent sessions.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+faster-whisper>=0.10.0
+python-slugify>=8.0.0

--- a/scripts/build_vtt.py
+++ b/scripts/build_vtt.py
@@ -1,0 +1,316 @@
+"""Utilities to align a Portuguese transcript and optional English translation
+with an audio file and export a WebVTT subtitle file suitable for the player
+included in this repository.
+
+The script relies on `faster-whisper` for light-weight forced alignment.  The
+alignment procedure transcribes the audio in European Portuguese, aligns the
+word-level timestamps with the provided transcript, and emits cues that contain
+both the original text and (optionally) an English translation.
+
+Example usage:
+
+    python scripts/build_vtt.py \
+        --audio ./examples/podcast.mp3 \
+        --portuguese ./examples/podcast.pt.txt \
+        --english ./examples/podcast.en.txt \
+        --model medium \
+        --output ./examples/podcast.vtt
+
+The Portuguese and English text files should contain exactly the same number of
+non-empty lines once comments and blank rows are stripped.  Each line represents
+a logical unit in the conversation (for example a speaker turn).  The script
+tries to align each of those units with the best matching span in the audio.  If
+alignment fails for a unit, the script falls back to an estimated duration based
+on neighbouring cues so that the resulting file is still usable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import math
+import re
+import unicodedata
+from pathlib import Path
+from typing import Iterable, Iterator, List, Optional, Sequence
+
+from faster_whisper import WhisperModel
+from slugify import slugify
+
+
+_WORD_RE = re.compile(r"\w+", re.UNICODE)
+
+
+@dataclasses.dataclass
+class TranscriptLine:
+    """Represents a single unit in the user's reference transcript."""
+
+    index: int
+    text: str
+    translation: Optional[str] = None
+
+
+@dataclasses.dataclass
+class Word:
+    """Represents a recognized word with normalized text and timestamps."""
+
+    text: str
+    normalized: str
+    start: float
+    end: float
+
+
+@dataclasses.dataclass
+class Cue:
+    """Represents a WebVTT cue."""
+
+    identifier: str
+    start: float
+    end: float
+    transcript: TranscriptLine
+
+    def to_vtt(self) -> str:
+        start = seconds_to_timestamp(self.start)
+        end = seconds_to_timestamp(self.end)
+        cue_body = f"<span class=\"pt\">{escape_vtt(self.transcript.text)}</span>"
+        if self.transcript.translation:
+            cue_body += "<br/><span class=\"en\">"
+            cue_body += escape_vtt(self.transcript.translation)
+            cue_body += "</span>"
+        return f"{self.identifier}\n{start} --> {end}\n{cue_body}\n"
+
+
+class AlignmentError(RuntimeError):
+    """Raised when the alignment process fails fatally."""
+
+
+def normalize_token(token: str) -> str:
+    token = token.casefold()
+    token = unicodedata.normalize("NFD", token)
+    token = "".join(ch for ch in token if unicodedata.category(ch) != "Mn")
+    token = re.sub(r"[^\w]", "", token)
+    return token
+
+
+def load_transcript(path: Path, translation_path: Optional[Path]) -> List[TranscriptLine]:
+    def iter_lines(p: Path) -> Iterator[str]:
+        for raw in p.read_text(encoding="utf-8").splitlines():
+            stripped = raw.strip()
+            if stripped and not stripped.startswith("#"):
+                yield stripped
+
+    portuguese_lines = list(iter_lines(path))
+    translations: List[Optional[str]]
+
+    if translation_path:
+        english_lines = list(iter_lines(translation_path))
+        if len(english_lines) != len(portuguese_lines):
+            raise AlignmentError(
+                "The Portuguese and English transcripts must have the same number of non-empty lines."
+            )
+        translations = english_lines
+    else:
+        translations = [None] * len(portuguese_lines)
+
+    return [
+        TranscriptLine(index=i, text=pt, translation=translations[i])
+        for i, pt in enumerate(portuguese_lines)
+    ]
+
+
+def transcribe_audio(model: WhisperModel, audio_path: Path, *, language: str) -> List[Word]:
+    """Transcribe the audio and return a flattened list of timestamped words."""
+
+    segments, _ = model.transcribe(
+        str(audio_path),
+        language=language,
+        beam_size=5,
+        word_timestamps=True,
+    )
+
+    words: List[Word] = []
+    for segment in segments:
+        for word in segment.words:
+            normalized = normalize_token(word.word)
+            if not normalized:
+                continue
+            words.append(
+                Word(
+                    text=word.word,
+                    normalized=normalized,
+                    start=float(word.start),
+                    end=float(word.end),
+                )
+            )
+    if not words:
+        raise AlignmentError("No words were recognized in the audio. Check the language parameter and audio quality.")
+    return words
+
+
+def align_transcript(lines: Sequence[TranscriptLine], words: Sequence[Word]) -> List[Cue]:
+    cues: List[Cue] = []
+    pointer = 0
+    word_count = len(words)
+    average_word_duration = sum(w.end - w.start for w in words) / max(word_count, 1)
+
+    for line in lines:
+        tokens = [normalize_token(token) for token in _WORD_RE.findall(line.text)]
+        token_matches: List[int] = []
+
+        for token in tokens:
+            best_index = None
+            best_score = 0.0
+            search_window = range(pointer, min(pointer + 30, word_count))
+            for idx in search_window:
+                candidate = words[idx].normalized
+                if not candidate:
+                    continue
+                if candidate == token:
+                    best_index = idx
+                    best_score = 1.0
+                    break
+                # Fallback to partial ratio to cope with punctuation differences.
+                score = similarity(token, candidate)
+                if score > best_score:
+                    best_score = score
+                    best_index = idx
+            if best_index is not None and best_score >= 0.6:
+                token_matches.append(best_index)
+                pointer = best_index + 1
+
+        if token_matches:
+            start_word = words[token_matches[0]]
+            end_word = words[token_matches[-1]]
+            start_time = start_word.start
+            end_time = end_word.end
+        else:
+            # Fallback: estimate a reasonable window around the current pointer.
+            start_idx = min(pointer, word_count - 1)
+            end_idx = min(start_idx + max(len(tokens), 1), word_count - 1)
+            start_time = words[start_idx].start
+            end_time = words[end_idx].end
+            pointer = end_idx + 1
+
+        # Guarantee strictly increasing timestamps.
+        if cues:
+            previous_end = cues[-1].end
+            start_time = max(start_time, previous_end + 1e-3)
+        if end_time <= start_time:
+            end_time = start_time + max(average_word_duration, 0.3)
+
+        identifier = f"line-{slugify(line.index, lowercase=False)}"
+        cues.append(Cue(identifier=identifier, start=start_time, end=end_time, transcript=line))
+
+    return cues
+
+
+def seconds_to_timestamp(value: float) -> str:
+    hours = int(value // 3600)
+    minutes = int((value % 3600) // 60)
+    seconds = int(value % 60)
+    milliseconds = int(round((value - math.floor(value)) * 1000))
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}.{milliseconds:03d}"
+
+
+def escape_vtt(text: str) -> str:
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
+
+
+def similarity(a: str, b: str) -> float:
+    """Compute a simple similarity ratio between two strings."""
+
+    if not a or not b:
+        return 0.0
+    matches = sum(1 for x, y in zip(a, b) if x == y)
+    return matches / max(len(a), len(b))
+
+
+def write_vtt(output_path: Path, cues: Sequence[Cue]) -> None:
+    with output_path.open("w", encoding="utf-8") as handle:
+        handle.write("WEBVTT\n\n")
+        for cue in cues:
+            handle.write(cue.to_vtt())
+            handle.write("\n")
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--audio", type=Path, required=True, help="Path to the MP3/MP4 audio file.")
+    parser.add_argument(
+        "--portuguese",
+        type=Path,
+        required=True,
+        help="Path to the Portuguese transcript (one speaker turn per line).",
+    )
+    parser.add_argument(
+        "--english",
+        type=Path,
+        help="Path to the English translation (one speaker turn per line).",
+    )
+    parser.add_argument(
+        "--model",
+        default="small",
+        help="Name or path of the Whisper model to use (default: small).",
+    )
+    parser.add_argument(
+        "--device",
+        default="auto",
+        help="Inference device for faster-whisper (auto, cpu, cuda).",
+    )
+    parser.add_argument(
+        "--language",
+        default="pt",
+        help="Language code for the audio (default: pt for Portuguese).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("output.vtt"),
+        help="Destination path for the generated WebVTT file.",
+    )
+    parser.add_argument(
+        "--dump-debug",
+        type=Path,
+        help="Optional path to export alignment diagnostics as JSON.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    args = parse_args(argv)
+
+    transcript_lines = load_transcript(args.portuguese, args.english)
+    model = WhisperModel(args.model, device=args.device)
+    words = transcribe_audio(model, args.audio, language=args.language)
+    cues = align_transcript(transcript_lines, words)
+    write_vtt(args.output, cues)
+
+    if args.dump_debug:
+        debug_payload = {
+            "audio": str(args.audio),
+            "portuguese": str(args.portuguese),
+            "english": str(args.english) if args.english else None,
+            "model": args.model,
+            "cues": [
+                {
+                    "index": cue.transcript.index,
+                    "start": cue.start,
+                    "end": cue.end,
+                    "text": cue.transcript.text,
+                    "translation": cue.transcript.translation,
+                }
+                for cue in cues
+            ],
+        }
+        args.dump_debug.write_text(json.dumps(debug_payload, indent=2), encoding="utf-8")
+
+    print(f"Generated {len(cues)} cues in {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Notebook LM Podcast Player</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Notebook LM Podcast Player</h1>
+        <p>
+          Load a Portuguese audio file and its WebVTT transcript to practice
+          listening with synchronized subtitles and English translations.
+        </p>
+      </header>
+
+      <section class="loader">
+        <label class="file-input">
+          <span>Audio file (MP3 / MP4 / WAV)</span>
+          <input id="audioInput" type="file" accept="audio/*,video/mp4" />
+        </label>
+        <label class="file-input">
+          <span>Transcript (WebVTT)</span>
+          <input id="vttInput" type="file" accept=".vtt" />
+        </label>
+        <label class="toggle">
+          <input id="translationToggle" type="checkbox" checked />
+          <span>Show English translation</span>
+        </label>
+      </section>
+
+      <section class="player">
+        <audio id="audioPlayer" controls preload="metadata"></audio>
+      </section>
+
+      <section class="transcript" id="transcript"></section>
+    </main>
+
+    <template id="cueTemplate">
+      <article class="cue" data-start="0" data-end="0">
+        <p class="pt"></p>
+        <p class="en"></p>
+      </article>
+    </template>
+
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/webapp/script.js
+++ b/webapp/script.js
@@ -1,0 +1,168 @@
+const audioInput = document.getElementById("audioInput");
+const vttInput = document.getElementById("vttInput");
+const translationToggle = document.getElementById("translationToggle");
+const audioPlayer = document.getElementById("audioPlayer");
+const transcriptContainer = document.getElementById("transcript");
+const cueTemplate = document.getElementById("cueTemplate");
+
+let cues = [];
+let activeCueIndex = -1;
+
+audioInput.addEventListener("change", handleAudioSelection);
+vttInput.addEventListener("change", handleVttSelection);
+audioPlayer.addEventListener("timeupdate", handleTimeUpdate);
+audioPlayer.addEventListener("seeking", () => updateActiveCue(audioPlayer.currentTime, true));
+translationToggle.addEventListener("change", handleTranslationToggle);
+
+function handleAudioSelection(event) {
+  const [file] = event.target.files;
+  if (!file) return;
+  const url = URL.createObjectURL(file);
+  audioPlayer.src = url;
+  audioPlayer.load();
+}
+
+async function handleVttSelection(event) {
+  const [file] = event.target.files;
+  if (!file) return;
+  const text = await file.text();
+  cues = parseVtt(text);
+  renderTranscript(cues);
+  activeCueIndex = -1;
+  updateActiveCue(audioPlayer.currentTime, true);
+}
+
+function handleTranslationToggle(event) {
+  transcriptContainer.classList.toggle("hide-translation", !event.target.checked);
+}
+
+function parseVtt(content) {
+  const lines = content.split(/\r?\n/);
+  const parsedCues = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    let line = lines[i].trim();
+    if (!line) {
+      i += 1;
+      continue;
+    }
+
+    // Identifier (optional)
+    let identifier = null;
+    if (!line.includes("-->")) {
+      identifier = line;
+      i += 1;
+      line = lines[i]?.trim() ?? "";
+    }
+
+    const timeMatch = line.match(/(?<start>[0-9:.]+)\s*-->\s*(?<end>[0-9:.]+)/);
+    if (!timeMatch) {
+      i += 1;
+      continue;
+    }
+
+    const start = parseTimestamp(timeMatch.groups.start);
+    const end = parseTimestamp(timeMatch.groups.end);
+    const textLines = [];
+    i += 1;
+
+    while (i < lines.length && lines[i].trim() !== "") {
+      textLines.push(lines[i]);
+      i += 1;
+    }
+
+    const html = textLines.join("\n");
+    parsedCues.push({ identifier, start, end, html });
+  }
+
+  return parsedCues;
+}
+
+function parseTimestamp(value) {
+  const [hh, mm, rest] = value.split(":");
+  const [ss, ms = "0"] = rest.split(".");
+  return parseInt(hh, 10) * 3600 + parseInt(mm, 10) * 60 + parseInt(ss, 10) + parseInt(ms, 10) / 1000;
+}
+
+function renderTranscript(cues) {
+  transcriptContainer.innerHTML = "";
+  cues.forEach((cue, index) => {
+    const node = cueTemplate.content.firstElementChild.cloneNode(true);
+    node.dataset.start = cue.start;
+    node.dataset.end = cue.end;
+    node.dataset.index = index;
+
+    const wrapper = document.createElement("div");
+    wrapper.innerHTML = cue.html;
+
+    const ptElement = node.querySelector(".pt");
+    const enElement = node.querySelector(".en");
+
+    const ptSource = wrapper.querySelector(".pt") || wrapper.firstElementChild;
+    const enSource = wrapper.querySelector(".en");
+
+    if (ptSource) {
+      ptElement.innerHTML = ptSource.innerHTML || ptSource.textContent || "";
+    }
+    if (enSource) {
+      enElement.innerHTML = enSource.innerHTML || enSource.textContent || "";
+    } else {
+      enElement.remove();
+    }
+
+    node.addEventListener("click", () => {
+      audioPlayer.currentTime = cue.start + 0.01;
+      audioPlayer.play();
+    });
+
+    transcriptContainer.appendChild(node);
+  });
+}
+
+function handleTimeUpdate() {
+  if (!cues.length) return;
+  updateActiveCue(audioPlayer.currentTime, false);
+}
+
+function updateActiveCue(currentTime, seeking) {
+  if (!cues.length) return;
+
+  const index = cues.findIndex((cue, idx) => {
+    if (idx < activeCueIndex) return false;
+    return currentTime >= cue.start && currentTime < cue.end + 0.05;
+  });
+
+  if (index === -1) {
+    if (currentTime < cues[0].start) {
+      setActiveCue(-1);
+    } else if (currentTime >= cues[cues.length - 1].end) {
+      setActiveCue(cues.length - 1);
+    }
+    return;
+  }
+
+  setActiveCue(index, seeking);
+}
+
+function setActiveCue(index, seeking = false) {
+  if (index === activeCueIndex) return;
+  const previous = transcriptContainer.querySelector(".cue.active");
+  if (previous) {
+    previous.classList.remove("active");
+  }
+
+  activeCueIndex = index;
+  if (index === -1) return;
+  const current = transcriptContainer.querySelector(`.cue[data-index="${index}"]`);
+  if (!current) return;
+  current.classList.add("active");
+
+  if (!seeking) {
+    current.scrollIntoView({ behavior: "smooth", block: "center" });
+  } else {
+    current.scrollIntoView({ behavior: "instant", block: "center" });
+  }
+}
+
+handleTranslationToggle({ target: translationToggle });

--- a/webapp/styles.css
+++ b/webapp/styles.css
@@ -1,0 +1,119 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  line-height: 1.5;
+  --accent: #2c7be5;
+  --bg: color-mix(in srgb, var(--accent) 6%, transparent);
+  --border: color-mix(in srgb, currentColor 20%, transparent);
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: #1f2933;
+}
+
+main {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+header h1 {
+  margin-bottom: 0.25rem;
+}
+
+header p {
+  margin-top: 0;
+  color: #334155;
+}
+
+.loader {
+  display: grid;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.file-input,
+.toggle {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+}
+
+.file-input input,
+.toggle input {
+  font: inherit;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.toggle {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+}
+
+.player {
+  margin-bottom: 1rem;
+}
+
+audio {
+  width: 100%;
+}
+
+.transcript {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: clamp(40vh, 60vh, 600px);
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.cue {
+  border: 1px solid transparent;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
+  transition: border-color 120ms ease, transform 120ms ease, background 120ms ease;
+  cursor: pointer;
+}
+
+.cue .pt {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0 0 0.25rem 0;
+}
+
+.cue .en {
+  font-size: 0.9rem;
+  margin: 0;
+  color: #475569;
+}
+
+.transcript.hide-translation .cue .en {
+  display: none;
+}
+
+.cue.active {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+  background: #fff;
+}
+
+@media (max-width: 600px) {
+  main {
+    padding: 1rem;
+  }
+
+  .cue {
+    padding: 0.6rem 0.75rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a Python CLI that aligns Portuguese audio with transcripts and exports WebVTT with optional English translations
- create a lightweight offline web player that loads local audio plus VTT files and keeps the transcript in sync with playback
- document the workflow for generating subtitles and using the player on Android

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68daedb3c5f8832893262a11f181b4d7